### PR TITLE
MVP with partial search and full RSVP

### DIFF
--- a/components/IncrementButtons.js
+++ b/components/IncrementButtons.js
@@ -1,8 +1,10 @@
 // import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import useFirebaseProfile from '../utils/hooks/useFirebaseProfile';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPersonCircleQuestion, faUserCheck, faUserMinus, faUserPlus } from '@fortawesome/free-solid-svg-icons';
+import {
+  faPersonCircleQuestion, faUserMinus, faUserPlus,
+} from '@fortawesome/free-solid-svg-icons';
+import useFirebaseProfile from '../utils/hooks/useFirebaseProfile';
 
 const AttendBtn = ({ postObj, updatePostHandler }) => {
   const theProfile = useFirebaseProfile();

--- a/components/IncrementButtons.js
+++ b/components/IncrementButtons.js
@@ -1,8 +1,8 @@
 // import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import useFirebaseProfile from '../utils/hooks/useFirebaseProfile';
-// import { faUserCheck } from '@fortawesome/free-solid-svg-icons';
-// import { FontAwesomeIcon } from 'fortawesome/react-fontawesome';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPersonCircleQuestion, faUserCheck, faUserMinus, faUserPlus } from '@fortawesome/free-solid-svg-icons';
 
 const AttendBtn = ({ postObj, updatePostHandler }) => {
   const theProfile = useFirebaseProfile();
@@ -41,13 +41,13 @@ const AttendBtn = ({ postObj, updatePostHandler }) => {
     <>
       <div className="rsvpBtns">
         <div>
-          <button className="likesButton" type="button" onClick={addAttend}>Joining: {postObj.attending ? postObj.attending : 0}</button>
+          <button className="bg-transparent border-0 me-1 pe-1" type="button" onClick={addAttend}><FontAwesomeIcon className="pe-2" icon={faUserPlus} />{postObj.attending ? postObj.attending : 0}</button>
         </div>
         <div>
-          <button className="likesButton" type="button" onClick={addNot}>Not Joining: {postObj.notAttending ? postObj.notAttending : 0} </button>
+          <button className="bg-transparent border-0 me-1 pe-1" type="button" onClick={addNot}><FontAwesomeIcon className="pe-2" icon={faUserMinus} />{postObj.notAttending ? postObj.notAttending : 0} </button>
         </div>
         <div>
-          <button className="likesButton" type="button" onClick={addMaybe}>Maybe: {postObj.maybe ? postObj.maybe : 0}</button>
+          <button className="bg-transparent border-0 pe-1" type="button" onClick={addMaybe}><FontAwesomeIcon className="pe-2" icon={faPersonCircleQuestion} />{postObj.maybe ? postObj.maybe : 0}</button>
         </div>
       </div>
     </>

--- a/components/IncrementButtons.js
+++ b/components/IncrementButtons.js
@@ -41,7 +41,8 @@ const AttendBtn = ({ postObj, updatePostHandler }) => {
   };
   return (
     <>
-      <div className="rsvpBtns">
+      <div className="d-flex w-75 mx-auto">
+        <p>RSVP:</p>
         <div>
           <button className="bg-transparent border-0 me-1 pe-1" type="button" onClick={addAttend}><FontAwesomeIcon className="pe-2" icon={faUserPlus} />{postObj.attending ? postObj.attending : 0}</button>
         </div>

--- a/components/NavBarAuth.js
+++ b/components/NavBarAuth.js
@@ -1,22 +1,39 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React from 'react';
-import Link from 'next/link';
+import React, { useState } from 'react';
+// import { useRouter } from 'next/router';
+// import Link from 'next/link';
 import {
   Navbar, Container, Nav, Button,
 } from 'react-bootstrap';
 import NavDropdown from 'react-bootstrap/NavDropdown';
+import PropTypes from 'prop-types';
 import Offcanvas from 'react-bootstrap/Offcanvas';
 import Form from 'react-bootstrap/Form';
 import { signOut } from '../utils/auth';
 import ProfileForm from './forms/ProfileForm';
+import { getAllPosts } from '../api/postData';
+import PostForm from './forms/PostForm';
 
-export default function NavBarAuth() {
+export default function NavBarAuth({ searchInput, setSearchInput }) {
+  // const router = useRouter();
+  const [posts, setPosts] = useState([]);
+  const getPosts = () => {
+    getAllPosts().then(setPosts);
+  };
+
+  console.log(posts);
+
+  const handleChange = (e) => {
+    setSearchInput(e.target.value.toLowerCase());
+  };
+
   return (
     <>
       {[false].map((expand) => (
         <Navbar key={expand} bg="light" expand={false} className="mb-3">
           <Container fluid>
             <Navbar.Brand href="/">GameRsvp</Navbar.Brand>
+            <PostForm onUpdate={getPosts} />
             <Navbar.Toggle aria-controls={`offcanvasNavbar-expand-${expand}`} />
             <Navbar.Offcanvas
               id={`offcanvasNavbar-expand-${expand}`}
@@ -55,8 +72,10 @@ export default function NavBarAuth() {
                     placeholder="Search"
                     className="me-2"
                     aria-label="Search"
+                    value={searchInput}
+                    onChange={handleChange}
                   />
-                  <Button variant="outline-success">Search</Button>
+                  <Button variant="outline-dark">Search</Button>
                 </Form>
                 <ProfileForm />
                 <Button className="modalForm bg-dark border-0" onClick={signOut}>Sign Out</Button>
@@ -87,3 +106,13 @@ export default function NavBarAuth() {
   // </Navbar>
   );
 }
+
+NavBarAuth.propTypes = {
+  searchInput: PropTypes.string,
+  setSearchInput: PropTypes.string,
+};
+
+NavBarAuth.defaultProps = {
+  searchInput: '',
+  setSearchInput: '',
+};

--- a/components/NavBarAuth.js
+++ b/components/NavBarAuth.js
@@ -22,7 +22,7 @@ export default function NavBarAuth() {
               <Nav.Link>Postings</Nav.Link>
             </Link>
             <ProfileForm />
-            <Button variant="danger" onClick={signOut}>Sign Out</Button>
+            <Button className="modalForm bg-transparent border-0" onClick={signOut}>Sign Out</Button>
           </Nav>
         </Navbar.Collapse>
       </Container>

--- a/components/NavBarAuth.js
+++ b/components/NavBarAuth.js
@@ -4,28 +4,86 @@ import Link from 'next/link';
 import {
   Navbar, Container, Nav, Button,
 } from 'react-bootstrap';
+import NavDropdown from 'react-bootstrap/NavDropdown';
+import Offcanvas from 'react-bootstrap/Offcanvas';
+import Form from 'react-bootstrap/Form';
 import { signOut } from '../utils/auth';
 import ProfileForm from './forms/ProfileForm';
 
 export default function NavBarAuth() {
   return (
-    <Navbar collapseOnSelect expand="lg" bg="dark" variant="dark">
-      <Container>
-        <Link passHref href="/profile">
-          <Navbar.Brand>Profile</Navbar.Brand>
-        </Link>
-        <Navbar.Toggle aria-controls="responsive-navbar-nav" />
-        <Navbar.Collapse id="responsive-navbar-nav">
-          <Nav className="me-auto">
-            {/* CLOSE NAVBAR ON LINK SELECTION: https://stackoverflow.com/questions/72813635/collapse-on-select-react-bootstrap-navbar-with-nextjs-not-working */}
-            <Link passHref href="/">
-              <Nav.Link>Postings</Nav.Link>
-            </Link>
-            <ProfileForm />
-            <Button className="modalForm bg-transparent border-0" onClick={signOut}>Sign Out</Button>
-          </Nav>
-        </Navbar.Collapse>
-      </Container>
-    </Navbar>
+    <>
+      {[false].map((expand) => (
+        <Navbar key={expand} bg="light" expand={false} className="mb-3">
+          <Container fluid>
+            <Navbar.Brand href="/">GameRsvp</Navbar.Brand>
+            <Navbar.Toggle aria-controls={`offcanvasNavbar-expand-${expand}`} />
+            <Navbar.Offcanvas
+              id={`offcanvasNavbar-expand-${expand}`}
+              aria-labelledby={`offcanvasNavbarLabel-expand-${expand}`}
+              placement="end"
+            >
+              <Offcanvas.Header closeButton>
+                <Offcanvas.Title id={`offcanvasNavbarLabel-expand-${expand}`}>
+                  Menu
+                </Offcanvas.Title>
+              </Offcanvas.Header>
+              <Offcanvas.Body>
+                <Nav className="justify-content-end flex-grow-1 pe-3">
+                  <Nav.Link href="/profile">Profile</Nav.Link>
+                  <Nav.Link href="/">Postings Home</Nav.Link>
+                  <NavDropdown
+                    title="Other Links"
+                    id={`offcanvasNavbarDropdown-expand-${expand}`}
+                  >
+                    <NavDropdown.Item href="https://www.playstation.com/en-us/">Playstation</NavDropdown.Item>
+                    <NavDropdown.Item href="https://www.xbox.com/en-US/">
+                      Xbox
+                    </NavDropdown.Item>
+                    <NavDropdown.Item href="https://www.pcgamer.com/">
+                      PC Gamer
+                    </NavDropdown.Item>
+                    <NavDropdown.Divider />
+                    <NavDropdown.Item href="#action5">
+                      Something else here
+                    </NavDropdown.Item>
+                  </NavDropdown>
+                </Nav>
+                <Form className="d-flex">
+                  <Form.Control
+                    type="search"
+                    placeholder="Search"
+                    className="me-2"
+                    aria-label="Search"
+                  />
+                  <Button variant="outline-success">Search</Button>
+                </Form>
+                <ProfileForm />
+                <Button className="modalForm bg-dark border-0" onClick={signOut}>Sign Out</Button>
+              </Offcanvas.Body>
+            </Navbar.Offcanvas>
+          </Container>
+        </Navbar>
+      ))}
+    </>
+
+  // <Navbar collapseOnSelect expand="lg" bg="dark" variant="dark">
+  //   <Container>
+  //     <Link passHref href="/profile">
+  //       <Navbar.Brand>Profile</Navbar.Brand>
+  //     </Link>
+  //     <Navbar.Toggle aria-controls="responsive-navbar-nav" />
+  //     <Navbar.Collapse id="responsive-navbar-nav">
+  //       <Nav className="me-auto">
+  //         {/* CLOSE NAVBAR ON LINK SELECTION: https://stackoverflow.com/questions/72813635/collapse-on-select-react-bootstrap-navbar-with-nextjs-not-working */}
+  //         <Link passHref href="/">
+  //           <Nav.Link>Postings</Nav.Link>
+  //         </Link>
+  //         <ProfileForm />
+  //         <Button className="modalForm bg-transparent border-0" onClick={signOut}>Sign Out</Button>
+  //       </Nav>
+  //     </Navbar.Collapse>
+  //   </Container>
+  // </Navbar>
   );
 }

--- a/components/PostsCard.js
+++ b/components/PostsCard.js
@@ -8,6 +8,7 @@ import { useAuth } from '../utils/context/authContext';
 import Buttons from './UserButtons';
 import { updatePost } from '../api/postData';
 import AttendBtn from './IncrementButtons';
+import RsvpBtn from './RsvpBtn';
 
 function PostCard({ postObj, onUpdate, profileObj }) {
   const { user } = useAuth();
@@ -27,15 +28,16 @@ function PostCard({ postObj, onUpdate, profileObj }) {
   return (
     <>
       <Card style={{ width: '18rem', margin: '10px' }}>
-        <Card.Img variant="top" src={profile?.avatar} alt={postObj?.title} style={{ height: '200px' }} />
+        <Card.Img variant="top" src={profile?.avatar} alt={postObj?.title} style={{ height: '150px' }} />
         <Card.Body>
-          <Card.Title style={{ color: 'red' }}>{postObj?.title}</Card.Title>
-          <h5 className="card-text bold" style={{ color: 'red' }}>Profile: {profile?.username}</h5>
+          <Card.Title style={{ color: 'red' }}>Game Session: {postObj?.title}</Card.Title>
+          <h6 className="card-text bold" style={{ color: 'black' }}>Profile: {profile?.username}</h6>
           <p className="card-text bold" style={{ color: 'red' }}>Session Details: {postObj?.postText}</p>
           <p className="card-text bold" style={{ color: 'red' }}>Day of Session: {postObj?.sessionDay}</p>
           <p className="card-text bold" style={{ color: 'red' }}>Session Time: {postObj?.sessionTime}</p>
           <Buttons postObj={updatedPost} onUpdate={onUpdate} />
-          <AttendBtn postObj={updatedPost} updatePostHandler={updatePostHandler} />
+          RSVP:<AttendBtn postObj={updatedPost} updatePostHandler={updatePostHandler} />
+          <RsvpBtn postObj={updatedPost} />
         </Card.Body>
       </Card>
     </>

--- a/components/PostsCard.js
+++ b/components/PostsCard.js
@@ -27,6 +27,21 @@ function PostCard({ postObj, onUpdate, profileObj }) {
 
   return (
     <>
+      <div className="flip-card">
+        <div className="flip-card-inner">
+          <div className="flip-card-front">
+            <p className="title">{postObj?.title}</p>
+            <p>{profile?.username}</p>
+            <p>Session Details: {postObj?.postText}</p>
+          </div>
+          <div className="flip-card-back">
+            <p className="title">{profile?.username}</p>
+            <p>Leave Me</p>
+            <img src={profile?.avatar} alt="avatar" />
+          </div>
+        </div>
+      </div>
+
       <Card style={{ width: '18rem', margin: '10px' }}>
         <Card.Img variant="top" src={profile?.avatar} alt={postObj?.title} style={{ height: '150px' }} />
         <Card.Body>

--- a/components/PostsCard.js
+++ b/components/PostsCard.js
@@ -33,7 +33,7 @@ function PostCard({ postObj, onUpdate, profileObj }) {
             <img height="150px" src={profile?.avatar} alt="avatar" />
             <h5>{profile?.username}</h5>
             <p>{profile?.gamertags}</p>
-            
+
           </div>
           <div className="flip-card-back">
             <p className="title">{postObj?.title}</p>
@@ -41,7 +41,7 @@ function PostCard({ postObj, onUpdate, profileObj }) {
             <p>Approximate Time: {postObj?.sessionTime}</p>
             <p>Details: {postObj?.postText}</p>
             <Buttons postObj={updatedPost} onUpdate={onUpdate} />
-            <p>RSVP:<AttendBtn postObj={updatedPost} updatePostHandler={updatePostHandler} /></p>
+            <p><AttendBtn postObj={updatedPost} updatePostHandler={updatePostHandler} /></p>
             <RsvpBtn postObj={updatedPost} />
           </div>
         </div>
@@ -56,7 +56,7 @@ function PostCard({ postObj, onUpdate, profileObj }) {
           <p className="card-text bold" style={{ color: 'red' }}>Day of Session: {postObj?.sessionDay}</p>
           <p className="card-text bold" style={{ color: 'red' }}>Session Time: {postObj?.sessionTime}</p>
           <Buttons postObj={updatedPost} onUpdate={onUpdate} />
-          RSVP:<AttendBtn postObj={updatedPost} updatePostHandler={updatePostHandler} />
+          <AttendBtn postObj={updatedPost} updatePostHandler={updatePostHandler} />
           <RsvpBtn postObj={updatedPost} />
         </Card.Body>
       </Card>

--- a/components/PostsCard.js
+++ b/components/PostsCard.js
@@ -30,14 +30,19 @@ function PostCard({ postObj, onUpdate, profileObj }) {
       <div className="flip-card">
         <div className="flip-card-inner">
           <div className="flip-card-front">
-            <p className="title">{postObj?.title}</p>
-            <p>{profile?.username}</p>
-            <p>Session Details: {postObj?.postText}</p>
+            <img height="150px" src={profile?.avatar} alt="avatar" />
+            <h5>{profile?.username}</h5>
+            <p>{profile?.gamertags}</p>
+            
           </div>
           <div className="flip-card-back">
-            <p className="title">{profile?.username}</p>
-            <p>Leave Me</p>
-            <img src={profile?.avatar} alt="avatar" />
+            <p className="title">{postObj?.title}</p>
+            <p>Day of Week: {postObj?.sessionDay}</p>
+            <p>Approximate Time: {postObj?.sessionTime}</p>
+            <p>Details: {postObj?.postText}</p>
+            <Buttons postObj={updatedPost} onUpdate={onUpdate} />
+            <p>RSVP:<AttendBtn postObj={updatedPost} updatePostHandler={updatePostHandler} /></p>
+            <RsvpBtn postObj={updatedPost} />
           </div>
         </div>
       </div>

--- a/components/RsvpBtn.js
+++ b/components/RsvpBtn.js
@@ -10,7 +10,7 @@ function RsvpBtn({ postObj }) {
   return (
     <>
       <Link href={`/posts/rsvp/${postObj?.firebaseKey}`} passHref>
-        <Button variant="outline-warning" size="sm" onClick={console.warn('this is the', postObj.firebaseKey)}>Session RSVP List</Button>
+        <Button className="btn-sm mx-auto" variant="outline-warning" size="sm" onClick={console.warn('this is the', postObj.firebaseKey)}>Session RSVP List</Button>
       </Link>
     </>
   );

--- a/components/RsvpBtn.js
+++ b/components/RsvpBtn.js
@@ -1,0 +1,35 @@
+import PropTypes from 'prop-types';
+import Button from 'react-bootstrap/Button';
+import Link from 'next/link';
+// import { useAuth } from '../utils/context/authContext';
+// import useFirebaseProfile from '../utils/hooks/useFirebaseProfile';
+
+function RsvpBtn({ postObj }) {
+  // const theProfile = useFirebaseProfile();
+
+  return (
+    <>
+      <Link href={`/posts/rsvp/${postObj?.firebaseKey}`} passHref>
+        <Button variant="outline-warning" size="sm" onClick={console.warn('this is the', postObj.firebaseKey)}>Session RSVP List</Button>
+      </Link>
+    </>
+  );
+}
+
+RsvpBtn.propTypes = {
+  postObj: PropTypes.shape({
+    dateOfPost: PropTypes.string,
+    postText: PropTypes.string,
+    title: PropTypes.string,
+    uid: PropTypes.string,
+    firebaseKey: PropTypes.string,
+    attending: PropTypes.number,
+    notAttending: PropTypes.number,
+    maybe: PropTypes.number,
+    sessionDay: PropTypes.string,
+    sessionTime: PropTypes.string,
+  }).isRequired,
+  // onUpdate: PropTypes.func.isRequired,
+};
+
+export default RsvpBtn;

--- a/components/UserButtons.js
+++ b/components/UserButtons.js
@@ -21,12 +21,14 @@ function Buttons({ postObj, onUpdate }) {
       theProfile?.uid === postObj.uid ? (
 
         <>
-          <Link href={`/posts/edit/${postObj?.firebaseKey}`} passHref>
-            <Button className="border-0" variant="dark" size="xs" onClick={console.warn('this is the', postObj.firebaseKey)}>EDIT</Button>
-          </Link>
-          <Button className="bg-transparent border-0" variant="danger" size="sm" onClick={deleteThisPost} className="m-2">
-            DELETE
-          </Button>
+          <div className="d-flex flex-wrap">
+            <Link href={`/posts/edit/${postObj?.firebaseKey}`} passHref>
+              <Button className="border-0 w-25 mx-sm-auto" variant="dark" size="sm" onClick={console.warn('this is the', postObj.firebaseKey)}>EDIT</Button>
+            </Link>
+            <Button className="m-2 w-25 mx-sm-auto text-black-75 btn-sm" variant="light" size="xs" onClick={deleteThisPost}>
+              DELETE
+            </Button>
+          </div>
         </>
 
       )

--- a/components/UserButtons.js
+++ b/components/UserButtons.js
@@ -22,9 +22,9 @@ function Buttons({ postObj, onUpdate }) {
 
         <>
           <Link href={`/posts/edit/${postObj?.firebaseKey}`} passHref>
-            <Button variant="info" onClick={console.warn('this is the', postObj.firebaseKey)}>EDIT</Button>
+            <Button variant="info" size="sm" onClick={console.warn('this is the', postObj.firebaseKey)}>EDIT</Button>
           </Link>
-          <Button variant="danger" onClick={deleteThisPost} className="m-2">
+          <Button variant="danger" size="sm" onClick={deleteThisPost} className="m-2">
             DELETE
           </Button>
         </>

--- a/components/UserButtons.js
+++ b/components/UserButtons.js
@@ -22,9 +22,9 @@ function Buttons({ postObj, onUpdate }) {
 
         <>
           <Link href={`/posts/edit/${postObj?.firebaseKey}`} passHref>
-            <Button variant="info" size="sm" onClick={console.warn('this is the', postObj.firebaseKey)}>EDIT</Button>
+            <Button className="border-0" variant="dark" size="xs" onClick={console.warn('this is the', postObj.firebaseKey)}>EDIT</Button>
           </Link>
-          <Button variant="danger" size="sm" onClick={deleteThisPost} className="m-2">
+          <Button className="bg-transparent border-0" variant="danger" size="sm" onClick={deleteThisPost} className="m-2">
             DELETE
           </Button>
         </>

--- a/components/forms/PostForm.js
+++ b/components/forms/PostForm.js
@@ -50,7 +50,9 @@ export default function PostForm({ obj, onUpdate }) {
         handleClose();
       });
     } else {
-      const payload = { ...formInput, uid: user.uid, dateOfPost: new Date(Date.now()) };
+      const payload = {
+        ...formInput, uid: user.uid, attending: 0, notAttending: 0, maybe: 0, dateOfPost: new Date(Date.now()),
+      };
       createPost(payload).then(({ name }) => {
         const patchPayload = { firebaseKey: name };
         updatePost(patchPayload).then(() => {

--- a/components/forms/PostForm.js
+++ b/components/forms/PostForm.js
@@ -46,7 +46,7 @@ export default function PostForm({ obj, onUpdate }) {
     e.preventDefault();
     if (obj.firebaseKey) {
       updatePost(formInput).then(() => {
-        onUpdate();
+        router.push('/');
         handleClose();
       });
     } else {
@@ -68,7 +68,7 @@ export default function PostForm({ obj, onUpdate }) {
   return (
     <>
       <Button
-        variant="primary"
+        variant="light"
         className="modalForm"
         onClick={handleShow}
       >

--- a/components/forms/ProfileForm.js
+++ b/components/forms/ProfileForm.js
@@ -67,8 +67,7 @@ export default function ProfileForm({ obj, onUpdate }) {
   return (
     <>
       <Button
-        variant="primary"
-        className="modalForm"
+        className="modalForm bg-transparent border-0"
         onClick={handleShow}
       >
         {obj?.firebaseKey ? 'Update Profile' : 'Create Profile'}

--- a/components/forms/ProfileForm.js
+++ b/components/forms/ProfileForm.js
@@ -67,7 +67,7 @@ export default function ProfileForm({ obj, onUpdate }) {
   return (
     <>
       <Button
-        className="modalForm bg-transparent border-0"
+        className="modalForm bg-dark border-0"
         onClick={handleShow}
       >
         {obj?.firebaseKey ? 'Update Profile' : 'Create Profile'}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@fortawesome/fontawesome-svg-core": "^6.4.0",
     "@fortawesome/free-regular-svg-icons": "^6.4.0",
     "@fortawesome/free-solid-svg-icons": "^6.4.0",
+    "@fortawesome/react-fontawesome": "^0.2.0",
     "axios": "^0.21.1",
     "bootstrap": "^5.1.3",
     "firebase": "^8.2.0",

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
 import { getAllProfiles, getSingleProfile } from '../api/profileData';
 import { getAllComments } from '../api/commentData';
 import { getAllPosts } from '../api/postData';
@@ -8,7 +9,7 @@ import ProfileForm from '../components/forms/ProfileForm';
 import PostCard from '../components/PostsCard';
 import PostForm from '../components/forms/PostForm';
 
-function Home() {
+function Home({ searchInput }) {
   const { user } = useAuth(); // TODO: COMMENT IN FOR AUTH
   const theProfile = useFirebaseProfile();
   const [profiles, setProfiles] = useState([]);
@@ -23,11 +24,11 @@ function Home() {
   console.warn('Hook result', theProfile);
 
   const getProfiles = () => {
-    getAllProfiles().then(setProfiles);
+    getAllProfiles()?.then(setProfiles);
   };
 
   const getUserProfile = () => {
-    getSingleProfile(user.uid).then(setProfile);
+    getSingleProfile(user.uid)?.then(setProfile);
   };
 
   const getPosts = () => {
@@ -51,7 +52,16 @@ function Home() {
     setCheckprof(profileCheck);
   }, [profiles, user.uid]);
 
-  // const user = { displayName: 'Dr. T' }; // TODO: COMMENT OUT FOR AUTH
+  const searchedPosts = posts?.filter((index) => index?.title.toLowerCase().includes(searchInput)
+  || index?.sessionDay?.toLowerCase().includes(searchInput)
+  || index?.sessionTime?.toLowerCase().includes(searchInput)
+  || index?.attendingNames?.toLowerCase().includes(searchInput)
+  || index?.postText?.toLowerCase().includes(searchInput));
+
+  // || index?.NotAttendingNames?.toLowerCase().includes(searchInput)
+  // || index?.attendingNames?.toLowerCase().includes(searchInput)
+  // || index?.maybeNames?.toLowerCase().includes(searchInput)
+
   console.warn('these are the gets', getAllComments(), getAllPosts(), getAllProfiles());
 
   return (
@@ -59,20 +69,21 @@ function Home() {
       {
       theProfile !== null ? (
         <>
+          <title>Cameron Dorris</title>
+
+          <PostForm onUpdate={getPosts} />
           <div className="d-flex flex-wrap">
             {/* map over posts using Card component */}
-            {posts.map((post) => (
+            {searchedPosts?.map((post) => (
               <PostCard key={post?.firebaseKey} profileObj={profiles} postObj={post} onUpdate={getPosts} />
             ))}
           </div>
-          <PostForm onUpdate={getPosts} />
         </>
       )
         : (
           <>
             <div>
               <ProfileForm />
-              <PostForm />
             </div>
             <div
               className="text-center d-flex flex-column justify-content-center align-content-center"
@@ -94,3 +105,11 @@ function Home() {
 }
 
 export default Home;
+
+Home.propTypes = {
+  searchInput: PropTypes.string,
+};
+
+Home.defaultProps = {
+  searchInput: '',
+};

--- a/pages/index.js
+++ b/pages/index.js
@@ -60,7 +60,6 @@ function Home() {
       theProfile !== null ? (
         <>
           <div className="d-flex flex-wrap">
-            this will be the landing of posts!
             {/* map over posts using Card component */}
             {posts.map((post) => (
               <PostCard key={post?.firebaseKey} profileObj={profiles} postObj={post} onUpdate={getPosts} />

--- a/pages/posts/edit/[firebaseKey].js
+++ b/pages/posts/edit/[firebaseKey].js
@@ -7,7 +7,7 @@ export default function EditPost() {
   const [editPost, setEditPost] = useState({});
   const router = useRouter();
   const { firebaseKey } = router.query;
-  console.warn('dynamic route', firebaseKey, router);
+  // console.warn('dynamic route', firebaseKey, router);
 
   useEffect(() => {
     getSinglePost(firebaseKey).then(setEditPost);

--- a/pages/posts/rsvp/[firebaseKey].js
+++ b/pages/posts/rsvp/[firebaseKey].js
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import Table from 'react-bootstrap/Table';
 import { getSinglePost } from '../../../api/postData';
-import { getAllProfiles, getSingleProfile } from '../../../api/profileData';
+import { getAllProfiles } from '../../../api/profileData';
 
 export default function PostRsvp() {
   const [post, setPost] = useState({});
@@ -16,26 +16,25 @@ export default function PostRsvp() {
     getAllProfiles().then((data) => data?.filter((index) => index?.uid === post.uid)).then(setProfile);
   }, [firebaseKey]);
 
-  // const attendRows = post?.attendingNames.forEach((index) => (
-  //   <tr>{index}</tr>
-  // ));
-
   console.log('table profile obj', profile, post);
 
   return (
     <Table striped="columns">
       <thead>
         <tr>
-          <th colSpan={3} style={{ color: 'red' }}><img style={{ height: '150px' }} src={profile?.avatar} alt="" />{post?.title}</th>
+          <th colSpan={1} style={{ color: 'red' }}><img style={{ height: '150px' }} src={profile?.avatar} alt="" />{post?.title}</th>
         </tr>
         <tr>
           <th>Joining Session</th>
-          <th>Not Joining</th>
-          <th>Maybe</th>
         </tr>
       </thead>
       <tbody>
-        <></>
+        {post?.attendingNames.map((index) => (
+          <tr>
+            <td>{index.attendingNames}</td>
+          </tr>
+        ))};
+
       </tbody>
     </Table>
   );

--- a/pages/posts/rsvp/[firebaseKey].js
+++ b/pages/posts/rsvp/[firebaseKey].js
@@ -2,45 +2,40 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import Table from 'react-bootstrap/Table';
 import { getSinglePost } from '../../../api/postData';
+import { getAllProfiles, getSingleProfile } from '../../../api/profileData';
 
 export default function PostRsvp() {
   const [post, setPost] = useState({});
+  const [profile, setProfile] = useState({});
   const router = useRouter();
   const { firebaseKey } = router.query;
   console.warn('dynamic route', firebaseKey, router, post);
 
   useEffect(() => {
     getSinglePost(firebaseKey).then(setPost);
+    getAllProfiles().then((data) => data?.filter((index) => index?.uid === post.uid)).then(setProfile);
   }, [firebaseKey]);
+
+  // const attendRows = post?.attendingNames.forEach((index) => (
+  //   <tr>{index}</tr>
+  // ));
+
+  console.log('table profile obj', profile, post);
 
   return (
     <Table striped="columns">
       <thead>
         <tr>
-          <th>RSVP</th>
+          <th colSpan={3} style={{ color: 'red' }}><img style={{ height: '150px' }} src={profile?.avatar} alt="" />{post?.title}</th>
+        </tr>
+        <tr>
           <th>Joining Session</th>
           <th>Not Joining</th>
           <th>Maybe</th>
         </tr>
       </thead>
       <tbody>
-        <tr>
-          <td>1</td>
-          <td>Mark</td>
-          <td>Otto</td>
-          <td>@mdo</td>
-        </tr>
-        <tr>
-          <td>2</td>
-          <td>Jacob</td>
-          <td>Thornton</td>
-          <td>@fat</td>
-        </tr>
-        <tr>
-          <td>3</td>
-          <td colSpan={2}>Larry the Bird</td>
-          <td>@twitter</td>
-        </tr>
+        <></>
       </tbody>
     </Table>
   );

--- a/pages/posts/rsvp/[firebaseKey].js
+++ b/pages/posts/rsvp/[firebaseKey].js
@@ -12,8 +12,8 @@ export default function PostRsvp() {
   // getSinglePost(firebaseKey).then((data) => setPost(data)).then(console.log('effect post', post));
 
   useEffect(() => {
-    getSinglePost(firebaseKey).then((data) => setPost(data));
-    getAllProfiles().then((data) => data.filter((index) => index.uid === post.uid)).then(setProfile);
+    getSinglePost(firebaseKey)?.then((data) => setPost(data));
+    getAllProfiles()?.then((data) => data?.filter((index) => index?.uid === post?.uid))?.then(setProfile);
   }, [firebaseKey]);
 
   // getAllProfiles().then((data) => console.log('this is the', data));
@@ -38,7 +38,7 @@ export default function PostRsvp() {
             </tr>
           </thead>
           <tbody>
-            {post?.attendingNames.map((index) => (
+            {post?.attendingNames?.map((index) => (
               <tr>
                 <td>{index}</td>
               </tr>
@@ -53,7 +53,7 @@ export default function PostRsvp() {
             </tr>
           </thead>
           <tbody>
-            {post?.NotAttendingNames.map((index) => (
+            {post?.NotAttendingNames?.map((index) => (
               <tr>
                 <td>{index}</td>
               </tr>
@@ -68,7 +68,7 @@ export default function PostRsvp() {
             </tr>
           </thead>
           <tbody>
-            {post?.maybeNames.map((index) => (
+            {post?.maybeNames?.map((index) => (
               <tr>
                 <td>{index}</td>
               </tr>

--- a/pages/posts/rsvp/[firebaseKey].js
+++ b/pages/posts/rsvp/[firebaseKey].js
@@ -13,7 +13,7 @@ export default function PostRsvp() {
 
   useEffect(() => {
     getSinglePost(firebaseKey).then((data) => setPost(data));
-    getAllProfiles().then((data) => data?.filter((index) => index?.uid === post?.uid)).then(setProfile);
+    getAllProfiles().then((data) => data.filter((index) => index.uid === post.uid)).then(setProfile);
   }, [firebaseKey]);
 
   // getAllProfiles().then((data) => console.log('this is the', data));

--- a/pages/posts/rsvp/[firebaseKey].js
+++ b/pages/posts/rsvp/[firebaseKey].js
@@ -9,33 +9,73 @@ export default function PostRsvp() {
   const [profile, setProfile] = useState({});
   const router = useRouter();
   const { firebaseKey } = router.query;
-  console.warn('dynamic route', firebaseKey, router, post);
+  // getSinglePost(firebaseKey).then((data) => setPost(data)).then(console.log('effect post', post));
 
   useEffect(() => {
-    getSinglePost(firebaseKey).then(setPost);
-    getAllProfiles().then((data) => data?.filter((index) => index?.uid === post.uid)).then(setProfile);
+    getSinglePost(firebaseKey).then((data) => setPost(data));
+    getAllProfiles().then((data) => data?.filter((index) => index?.uid === post?.uid)).then(setProfile);
   }, [firebaseKey]);
 
-  console.log('table profile obj', profile, post);
+  // getAllProfiles().then((data) => console.log('this is the', data));
+  // console.log('dynamic route', firebaseKey, router, post);
+  // console.log('dynamic post', post);
+  // console.log('get post', getSinglePost(firebaseKey));
+
+  // console.log('table profile obj', profile);
+  // console.log('post map', post?.attendingNames);
 
   return (
-    <Table striped="columns">
-      <thead>
-        <tr>
-          <th colSpan={1} style={{ color: 'red' }}><img style={{ height: '150px' }} src={profile?.avatar} alt="" />{post?.title}</th>
-        </tr>
-        <tr>
-          <th>Joining Session</th>
-        </tr>
-      </thead>
-      <tbody>
-        {post?.attendingNames.map((index) => (
-          <tr>
-            <td>{index.attendingNames}</td>
-          </tr>
-        ))};
+    <>
+      <div>
+        <img style={{ height: '150px' }} src={profile?.avatar} alt="avatar here" />
+        <h2 style={{ color: 'red' }}>{post?.title}</h2>
+      </div>
+      <div className="tables">
+        <Table striped>
+          <thead>
+            <tr>
+              <th>Attending Session</th>
+            </tr>
+          </thead>
+          <tbody>
+            {post?.attendingNames.map((index) => (
+              <tr>
+                <td>{index}</td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
 
-      </tbody>
-    </Table>
+        <Table striped>
+          <thead>
+            <tr>
+              <th>Not Attending</th>
+            </tr>
+          </thead>
+          <tbody>
+            {post?.NotAttendingNames.map((index) => (
+              <tr>
+                <td>{index}</td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+
+        <Table striped>
+          <thead>
+            <tr>
+              <th>Possible Attendees</th>
+            </tr>
+          </thead>
+          <tbody>
+            {post?.maybeNames.map((index) => (
+              <tr>
+                <td>{index}</td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      </div>
+    </>
   );
 }

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -48,7 +48,7 @@ function Profile() {
         <ProfileForm obj={theProfile} onUpdate={getProfile} />
       </div>
 
-      <div>
+      <div className="d-flex flex-wrap">
         this will be the landing of posts!
         {/* map over posts using Card component */}
         {userPosts.map((post) => (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -35,14 +35,19 @@ th {
 
 .flip-card {
   background-color: transparent;
-  width: 190px;
-  height: 254px;
+  width: 250px;
+  height: 320px;
   perspective: 1000px;
   font-family: sans-serif;
 }
 
+.flip-card-back > p {
+  font-size: small;
+  font-family: sans-serif;
+}
+
 .title {
-  font-size: 1.5em;
+  font-size: 1.25em;
   font-weight: 900;
   text-align: center;
   margin: 0;
@@ -79,6 +84,10 @@ th {
   background: linear-gradient(120deg, bisque 60%, rgb(255, 231, 222) 88%,
      rgb(255, 211, 195) 40%, rgba(255, 127, 80, 0.603) 48%);
   color: coral;
+}
+
+.flip-card-front > img {
+  border-radius: 50%;
 }
 
 .flip-card-back {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -32,3 +32,58 @@ th {
   display: flex;
   flex-direction: row;
 }
+
+.flip-card {
+  background-color: transparent;
+  width: 190px;
+  height: 254px;
+  perspective: 1000px;
+  font-family: sans-serif;
+}
+
+.title {
+  font-size: 1.5em;
+  font-weight: 900;
+  text-align: center;
+  margin: 0;
+}
+
+.flip-card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  transition: transform 0.8s;
+  transform-style: preserve-3d;
+}
+
+.flip-card:hover .flip-card-inner {
+  transform: rotateY(180deg);
+}
+
+.flip-card-front, .flip-card-back {
+  box-shadow: 0 8px 14px 0 rgba(0,0,0,0.2);
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  border: 1px solid coral;
+  border-radius: 1rem;
+}
+
+.flip-card-front {
+  background: linear-gradient(120deg, bisque 60%, rgb(255, 231, 222) 88%,
+     rgb(255, 211, 195) 40%, rgba(255, 127, 80, 0.603) 48%);
+  color: coral;
+}
+
+.flip-card-back {
+  background: linear-gradient(120deg, rgb(255, 174, 145) 30%, coral 88%,
+     bisque 40%, rgb(255, 185, 160) 78%);
+  color: white;
+  transform: rotateY(180deg);
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -28,3 +28,7 @@ body {
 th {
   text-align: center;
 }
+.tables {
+  display: flex;
+  flex-direction: row;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -18,10 +18,13 @@ a {
 }
 
 body {
-  background-color: #88effd;
+  background-color: grey;
 }
 
 .rsvpBtns {
   display:flex;
   flex-wrap: wrap;
+}
+th {
+  text-align: center;
 }

--- a/utils/ViewDirector.js
+++ b/utils/ViewDirector.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { useState } from 'react';
 import { useAuth } from './context/authContext';
 import Loading from '../components/Loading';
 import Signin from '../components/Signin';
@@ -6,6 +7,7 @@ import NavBarAuth from '../components/NavBarAuth';
 
 const ViewDirectorBasedOnUserAuthStatus = ({ component: Component, pageProps }) => {
   const { user, userLoading } = useAuth();
+  const [searchInput, setSearchInput] = useState('');
 
   // if user state is null, then show loader
   if (userLoading) {
@@ -16,9 +18,9 @@ const ViewDirectorBasedOnUserAuthStatus = ({ component: Component, pageProps }) 
   if (user) {
     return (
       <>
-        <NavBarAuth /> {/* NavBar only visible if user is logged in and is in every view */}
+        <NavBarAuth searchInput={searchInput} setSearchInput={setSearchInput} /> {/* NavBar only visible if user is logged in and is in every view */}
         <div className="container">
-          <Component {...pageProps} />
+          <Component {...pageProps} searchInput={searchInput} setSearchInput={setSearchInput} />
         </div>
       </>
     );


### PR DESCRIPTION
## Description
Basic CRUD. Off canvas search partially functional for posts. RSVP table displays on new page.

## Related Issue
CRUD for posts. CRU for Profile. 
Search stretch partially there. Will search on certain key value pairs of post object

## Motivation and Context
Basic CRUD was met moved toward stretch functionality.

## How Can This Be Tested?
Posts were successfully created, read, updated, and deleted. Search input returns searched posts. RSVP table renders on button click.

## Screenshots (if appropriate):

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
